### PR TITLE
Add JP monogram logo to navbar

### DIFF
--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,0 +1,21 @@
+function Logo() {
+    return (
+        <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect width="40" height="40" rx="6" fill="#22d3ee" fillOpacity="0.1" stroke="#22d3ee" strokeWidth="1.5"/>
+            <text
+                x="50%"
+                y="52%"
+                dominantBaseline="central"
+                textAnchor="middle"
+                fill="#22d3ee"
+                fontFamily="monospace"
+                fontWeight="700"
+                fontSize="16"
+            >
+                JP
+            </text>
+        </svg>
+    );
+}
+
+export default Logo;

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import Logo from './Logo';
 
 function Navigation() {
     const [mobileOpen, setMobileOpen] = useState(false);
@@ -8,8 +9,9 @@ function Navigation() {
         <nav className="fixed top-0 w-full z-50 bg-slate-900/90 backdrop-blur-sm border-b border-slate-800">
             <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex items-center justify-between h-16">
-                    <Link to="/" className="text-cyan-400 font-bold text-xl font-mono">
-                        Jonathan Pho
+                    <Link to="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+                        <Logo />
+                        <span className="text-white font-semibold text-sm hidden sm:block">Jonathan Pho</span>
                     </Link>
 
                     <div className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- Add new `Logo` component — inline SVG with a cyan-bordered rounded square and "JP" monogram
- Replace plain text brand link in `Navigation` with the logo and name side by side

## Test plan
- [ ] Logo displays in navbar on desktop and mobile
- [ ] Clicking logo navigates to home page
- [ ] Name hides correctly on small screens (visible on `sm` and above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)